### PR TITLE
Update Supabase service key placeholder in documentation

### DIFF
--- a/MCP_SERVER_CHECKPOINT.md
+++ b/MCP_SERVER_CHECKPOINT.md
@@ -126,7 +126,7 @@ const ws = new WebSocket('ws://localhost:9083/mcp');
 ### Supabase Production Setup
 ```bash
 SUPABASE_URL=https://mxtsdgkwzjzlttpotole.supabase.co
-SUPABASE_SERVICE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im14dHNkZ2t3emp6bHR0cG90b2xlIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0NzEwNTI1OSwiZXhwIjoyMDYyNjgxMjU5fQ.Aoob84MEgNV-viFugZHWKodJUjn4JOQNzcSQ57stJFU
+SUPABASE_SERVICE_KEY=[your_service_key_here]
 ```
 
 ### Key Tables


### PR DESCRIPTION
This pull request updates the documentation for Supabase production setup by replacing the hardcoded service key with a placeholder. This change improves security and prevents accidental exposure of sensitive credentials.

Security improvements:

* Updated `SUPABASE_SERVICE_KEY` in `MCP_SERVER_CHECKPOINT.md` to use `[your_service_key_here]` instead of a real service key, reducing the risk of leaking credentials in documentation.removed test key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated production setup example to use a placeholder for the Supabase service key, improving clarity and preventing exposure of sensitive-looking values.
  * Refined configuration example text for safer, more accurate guidance.

* **Style**
  * Minor formatting cleanup for consistency (added a missing trailing newline).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->