### PR TITLE
fix(auth-gateway): unblock Render build (Zod v4 env schema)

### DIFF
--- a/services/auth-gateway/config/env.ts
+++ b/services/auth-gateway/config/env.ts
@@ -18,7 +18,8 @@ const optionalIntegerString = () => z.coerce.number().int().optional()
 
 const requiredString = (name: string) =>
   z
-    .string({ required_error: `${name} is required` })
+    // Zod v4 removed `required_error`; use `message` to customize the invalid_type error.
+    .string({ message: `${name} is required` })
     .min(1, `${name} is required`)
 
 const optionalNonEmptyString = (name: string) =>


### PR DESCRIPTION
Render build is failing with TS2769 because Zod v4 removed `required_error` on `z.string()`.

This PR updates `services/auth-gateway/config/env.ts` to use Zod v4-compatible options (`message`) while keeping the same validation behavior.

Validation:
- Ran `bun install && bun run build` in `services/auth-gateway` locally; `tsc -p .` passes.