### PR TITLE
feat(p4): memory-context shared resolver + memory-search boundary enforcement

### DIFF
--- a/supabase/functions/_shared/memory-context.ts
+++ b/supabase/functions/_shared/memory-context.ts
@@ -24,6 +24,11 @@ export interface MemoryBoundaryResolution {
   user_id: string | null;
 }
 
+export interface MemoryBoundaryQueryFilters {
+  organization_id: string | null;
+  user_id: string | null;
+}
+
 function envFlag(name: string): boolean {
   const value = Deno.env.get(name)?.trim().toLowerCase();
   return value === "1" || value === "true" || value === "yes" || value === "on";
@@ -125,6 +130,41 @@ export function resolveMemoryBoundary(
   };
 }
 
+export function getMemoryBoundaryQueryFilters(
+  resolution: MemoryBoundaryResolution,
+): MemoryBoundaryQueryFilters {
+  return {
+    organization_id: resolution.organization_id,
+    user_id: resolution.flags.enforce ? resolution.user_id : null,
+  };
+}
+
+export function logMemoryBoundary(
+  resolution: MemoryBoundaryResolution,
+  auth: MemoryBoundaryAuthContext,
+  options: { requestId?: string; route?: string } = {},
+): void {
+  if (!resolution.flags.shadow && !resolution.flags.enforce) return;
+
+  const filters = getMemoryBoundaryQueryFilters(resolution);
+  console.info(
+    "[memory-context]",
+    JSON.stringify({
+      route: options.route || "unknown",
+      request_id: options.requestId || null,
+      auth_source: auth.auth_source || "unknown",
+      api_key_id: auth.api_key_id || null,
+      project_scope: auth.project_scope || null,
+      context: resolution.context,
+      enforce: resolution.flags.enforce,
+      intended_organization_id: resolution.organization_id,
+      intended_user_id: resolution.user_id,
+      applied_organization_id: filters.organization_id,
+      applied_user_id: filters.user_id,
+    }),
+  );
+}
+
 export function applyMemoryBoundary<T>(
   query: T,
   auth: MemoryBoundaryAuthContext,
@@ -132,37 +172,23 @@ export function applyMemoryBoundary<T>(
 ): T {
   let scopedQuery = query as Record<string, unknown>;
   const resolution = resolveMemoryBoundary(auth);
+  const filters = getMemoryBoundaryQueryFilters(resolution);
 
-  if (resolution.organization_id) {
+  if (filters.organization_id) {
     scopedQuery =
       (scopedQuery as { eq: (column: string, value: unknown) => unknown }).eq(
         "organization_id",
-        resolution.organization_id,
+        filters.organization_id,
       ) as Record<string, unknown>;
   }
 
-  if (resolution.flags.shadow || resolution.flags.enforce) {
-    console.info(
-      "[memory-context]",
-      JSON.stringify({
-        route: options.route || "unknown",
-        request_id: options.requestId || null,
-        auth_source: auth.auth_source || "unknown",
-        api_key_id: auth.api_key_id || null,
-        project_scope: auth.project_scope || null,
-        context: resolution.context,
-        enforce: resolution.flags.enforce,
-        organization_id: resolution.organization_id,
-        user_id: resolution.user_id,
-      }),
-    );
-  }
+  logMemoryBoundary(resolution, auth, options);
 
-  if (resolution.flags.enforce && resolution.user_id) {
+  if (filters.user_id) {
     scopedQuery =
       (scopedQuery as { eq: (column: string, value: unknown) => unknown }).eq(
         "user_id",
-        resolution.user_id,
+        filters.user_id,
       ) as Record<string, unknown>;
   }
 

--- a/supabase/functions/memory-search/index.ts
+++ b/supabase/functions/memory-search/index.ts
@@ -12,6 +12,8 @@ import { corsHeaders, handleCors } from "../_shared/cors.ts";
 import { createErrorResponse, ErrorCode } from "../_shared/errors.ts";
 import {
   applyMemoryBoundary,
+  getMemoryBoundaryQueryFilters,
+  logMemoryBoundary,
   resolveMemoryBoundary,
 } from "../_shared/memory-context.ts";
 
@@ -428,6 +430,8 @@ serve(async (req: Request) => {
     const typeFilters = normalizeTypes(body.memory_type, body.memory_types);
     const primaryFilterType = typeFilters.length === 1 ? typeFilters[0] : null;
     const boundary = resolveMemoryBoundary(auth);
+    const boundaryFilters = getMemoryBoundaryQueryFilters(boundary);
+    logMemoryBoundary(boundary, auth, { route: "memory-search:semantic" });
 
     let thresholdUsed = threshold;
     let searchStrategy:
@@ -441,8 +445,8 @@ serve(async (req: Request) => {
       queryEmbedding,
       thresholdUsed,
       limit,
-      boundary.organization_id,
-      boundary.user_id,
+      boundaryFilters.organization_id,
+      boundaryFilters.user_id,
       primaryFilterType,
     );
 
@@ -485,8 +489,8 @@ serve(async (req: Request) => {
           queryEmbedding,
           relaxed,
           limit,
-          boundary.organization_id,
-          boundary.user_id,
+          boundaryFilters.organization_id,
+          boundaryFilters.user_id,
           primaryFilterType,
         );
         if (!relaxedResponse.error && Array.isArray(relaxedResponse.data)) {
@@ -568,7 +572,7 @@ serve(async (req: Request) => {
       requested_threshold: threshold,
       search_strategy: searchStrategy,
       total: filteredResults.length,
-      organization_id: boundary.organization_id ?? auth.organization_id,
+      organization_id: boundaryFilters.organization_id ?? auth.organization_id,
       memory_context: boundary.context,
     };
 

--- a/tests/unit/memory-context.test.ts
+++ b/tests/unit/memory-context.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   applyMemoryBoundary,
+  getMemoryBoundaryQueryFilters,
+  logMemoryBoundary,
   resolveMemoryBoundary,
   resolveMemoryContext,
 } from '../../supabase/functions/_shared/memory-context.ts';
@@ -110,5 +112,68 @@ describe('memory-context helpers', () => {
       { op: 'eq', column: 'organization_id', value: 'org-1' },
       { op: 'eq', column: 'user_id', value: 'user-1' },
     ]);
+  });
+
+  it('keeps semantic RPC user filters disabled in shadow mode', () => {
+    env.FEATURE_MEMORY_CONTEXT_SHADOW = 'true';
+
+    const boundary = resolveMemoryBoundary({
+      user_id: 'user-1',
+      organization_id: 'org-1',
+      key_context: 'personal',
+      permissions: ['memories:personal:*'],
+    });
+
+    expect(getMemoryBoundaryQueryFilters(boundary)).toEqual({
+      organization_id: 'org-1',
+      user_id: null,
+    });
+  });
+
+  it('enables semantic RPC user filters in enforce mode', () => {
+    env.FEATURE_MEMORY_CONTEXT_ENFORCE = 'true';
+
+    const boundary = resolveMemoryBoundary({
+      user_id: 'user-1',
+      organization_id: 'org-1',
+      key_context: 'personal',
+      permissions: ['memories:personal:*'],
+    });
+
+    expect(getMemoryBoundaryQueryFilters(boundary)).toEqual({
+      organization_id: 'org-1',
+      user_id: 'user-1',
+    });
+  });
+
+  it('logs intended and applied personal boundary separately', () => {
+    env.FEATURE_MEMORY_CONTEXT_SHADOW = 'true';
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const auth = {
+      user_id: 'user-1',
+      organization_id: 'org-1',
+      key_context: 'personal',
+      permissions: ['memories:personal:*'],
+      auth_source: 'api_key',
+    };
+
+    logMemoryBoundary(resolveMemoryBoundary(auth), auth, {
+      route: 'memory-search:semantic',
+    });
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(String(infoSpy.mock.calls[0]?.[1]));
+    expect(payload).toMatchObject({
+      route: 'memory-search:semantic',
+      context: 'personal',
+      enforce: false,
+      intended_organization_id: 'org-1',
+      intended_user_id: 'user-1',
+      applied_organization_id: 'org-1',
+      applied_user_id: null,
+    });
+
+    infoSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Persists the P4 closure work declared on 2026-05-07 (memory-context-separation plan).

- Shared `memory-context` resolver enforces personal/team/enterprise/none boundaries via `applyMemoryBoundary()`
- `memory-search` edge function applies the resolved boundary to vector search
- Unit test coverage for resolution

## Why

P4 was approved on 2026-05-07 but the supporting code edits inside this submodule were never committed. This PR persists them so the monorepo can advance the submodule pointer for the context-engine upgrade Phase 0 closeout.

## Test plan

- [ ] Unit test passes (`tests/unit/memory-context.test.ts`)
- [ ] Endpoint smoke test on `memory-search` post-deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved memory boundary handling by introducing dedicated query-filter and logging helpers for better separation of concerns and maintainability.

* **Tests**
  * Enhanced test coverage for memory boundary behavior in both shadow and enforce modes, including validation of logging outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->